### PR TITLE
[TON-747] add pubkey query parameter and total bonuses to validator rewards

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Query parameters:
 | `block`       | uint32| Masterchain block seqno within the finished round                |
 | `unixtime`    | uint32| Unix timestamp (seconds). Looks up the masterchain block at this time and uses it as the anchor. |
 | `shallow`     | flag  | Set `shallow=1` to return only basic validator info (rank, pubkey, effective_stake, weight, reward, pool). Skips pool type detection, owner/validator addresses, nominator data, and returned-stake lookup — significantly faster. |
+| `pubkey`      | repeated | Lowercase hex validator pubkey (64 chars), repeatable (`?pubkey=a&pubkey=b`). When set, only the listed validators are deep-enriched; all others are returned with shallow fields regardless of `shallow`. |
 
 `election_id`, `block`, and `unixtime` are mutually exclusive. At least one is required.
 
@@ -155,6 +156,7 @@ Query parameters:
 | `seqno`      | uint32 | Masterchain block seqno (defaults to latest). Mutually exclusive with `unixtime`. |
 | `unixtime`   | uint32 | Unix timestamp (seconds). Looks up the masterchain block at this time. Mutually exclusive with `seqno`. |
 | `shallow`    | flag   | Set `shallow=1` to return only basic validator info (rank, pubkey, effective_stake, weight, reward, pool). Skips pool type detection, owner/validator addresses, nominator data, and returned-stake lookup — significantly faster. |
+| `pubkey`     | repeated | Lowercase hex validator pubkey (64 chars), repeatable (`?pubkey=a&pubkey=b`). When set, only the listed validators are deep-enriched; all others are returned with shallow fields regardless of `shallow`. |
 
 Response:
 
@@ -172,6 +174,8 @@ Response:
   "elector_balance": "966674188286983322",
   "total_stake": "457752122739238021",
   "reward_per_block": "2928989965",
+  "prev_block_total_bonuses": "75324846742804",
+  "curr_block_total_bonuses": "75327775732769",
   "validators": [
     {
       "rank": 1,
@@ -179,6 +183,7 @@ Response:
       "effective_stake": "2127654606060000",
       "weight": 0.004648,
       "reward": "13614090",
+      "curr_block_total_bonuses": "350123456789",
       "total_stake": "2376902585342169",
       "pool": "Ef_bmCmMPsrHKOC4hV8foWBs2TEUAggQ1Wfe6EAqjrI3sGNI",
       "pool_type": "nominator-pool-v1.0",
@@ -193,6 +198,7 @@ Response:
           "address": "EQAqR4RYauq7p3jqKGnD-eSYVDoOCak9g8ZsSNVHI9fevCzB",
           "weight": 1.0,
           "reward": "13614090",
+          "curr_block_total_bonuses": "245086419752",
           "effective_stake": "2127654606060000",
           "stake": "2176902585342169"
         }
@@ -214,6 +220,8 @@ Response:
 | `elector_balance` | Elector contract balance (nanoTON) |
 | `total_stake` | Sum of all active validators' effective stakes (nanoTON) |
 | `reward_per_block` | Total fees collected in the target block (nanoTON) |
+| `prev_block_total_bonuses` | Elector's accumulated bonuses for the current round at the previous masterchain block (nanoTON) |
+| `curr_block_total_bonuses` | Elector's accumulated bonuses for the current round at the target masterchain block (nanoTON) |
 
 #### Validator fields
 
@@ -224,6 +232,7 @@ Response:
 | `effective_stake` | Validator's true stake locked in the Elector contract (nanoTON) |
 | `weight` | Fraction of the total effective stake held by this validator (0–1) |
 | `reward` | Estimated reward this validator earns per masterchain block (nanoTON) |
+| `curr_block_total_bonuses` | Validator's share of `curr_block_total_bonuses`, computed as `curr_block_total_bonuses * effective_stake / total effective stake` (nanoTON) |
 | `pool` | Pool smart contract address (bounceable, base64url) |
 | `validator_address` | Validator's wallet address (the one that controls the node) |
 | `owner_address` | The single owner who deposited funds. Only present for single-nominator pools |
@@ -242,6 +251,7 @@ Response:
 | `address` | Nominator's wallet address (bounceable, base64url) |
 | `weight` | Nominator's share of the total nominators' deposit (0–1) |
 | `reward` | Estimated per-block reward after the validator's cut (nanoTON) |
+| `curr_block_total_bonuses` | Nominator's share of the validator's `curr_block_total_bonuses` after applying `validator_reward_share` (nanoTON) |
 | `effective_stake` | Nominator's proportional share of the effective stake locked in the Elector (nanoTON) |
 | `stake` | Nominator's raw deposit in the pool contract (nanoTON) |
 

--- a/api/handler.go
+++ b/api/handler.go
@@ -15,9 +15,9 @@ import (
 
 // ValidatorService describes the methods the API layer needs from the service layer.
 type ValidatorService interface {
-	FetchPerBlockRewards(ctx context.Context, seqno *uint32, unixtime *uint32, shallow bool, pubkeys map[string]struct{}) (*model.Output, error)
+	FetchPerBlockRewards(ctx context.Context, seqno *uint32, unixtime *uint32, shallow bool, pubkeys map[string]bool) (*model.Output, error)
 	FetchValidationRounds(ctx context.Context, query model.RoundsQuery) (*model.ValidationRoundsOutput, error)
-	FetchRoundRewards(ctx context.Context, query model.RoundRewardsQuery, shallow bool, pubkeys map[string]struct{}) (*model.RoundRewardsOutput, error)
+	FetchRoundRewards(ctx context.Context, query model.RoundRewardsQuery, shallow bool, pubkeys map[string]bool) (*model.RoundRewardsOutput, error)
 }
 
 // Handler holds dependencies for HTTP handlers.
@@ -232,12 +232,12 @@ func parseUnixtime(r *http.Request) (*uint32, error) {
 
 // parsePubkeys extracts the optional pubkey query parameter. Accepts repeated
 // occurrences (?pubkey=a&pubkey=b). Each value must be 64 lowercase hex chars.
-func parsePubkeys(r *http.Request) (map[string]struct{}, error) {
+func parsePubkeys(r *http.Request) (map[string]bool, error) {
 	values := r.URL.Query()["pubkey"]
 	if len(values) == 0 {
 		return nil, nil
 	}
-	set := make(map[string]struct{})
+	set := make(map[string]bool)
 	for _, v := range values {
 		p := strings.ToLower(strings.TrimSpace(v))
 		if p == "" {
@@ -251,7 +251,7 @@ func parsePubkeys(r *http.Request) (map[string]struct{}, error) {
 				return nil, fmt.Errorf("invalid pubkey %q: non-hex character", p)
 			}
 		}
-		set[p] = struct{}{}
+		set[p] = true
 	}
 	if len(set) == 0 {
 		return nil, nil

--- a/api/handler.go
+++ b/api/handler.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/the-ton-tech/ton-validators-rewards-api/model"
@@ -14,9 +15,9 @@ import (
 
 // ValidatorService describes the methods the API layer needs from the service layer.
 type ValidatorService interface {
-	FetchPerBlockRewards(ctx context.Context, seqno *uint32, unixtime *uint32, shallow bool) (*model.Output, error)
+	FetchPerBlockRewards(ctx context.Context, seqno *uint32, unixtime *uint32, shallow bool, pubkeys map[string]struct{}) (*model.Output, error)
 	FetchValidationRounds(ctx context.Context, query model.RoundsQuery) (*model.ValidationRoundsOutput, error)
-	FetchRoundRewards(ctx context.Context, query model.RoundRewardsQuery, shallow bool) (*model.RoundRewardsOutput, error)
+	FetchRoundRewards(ctx context.Context, query model.RoundRewardsQuery, shallow bool, pubkeys map[string]struct{}) (*model.RoundRewardsOutput, error)
 }
 
 // Handler holds dependencies for HTTP handlers.
@@ -49,8 +50,13 @@ func (h *Service) HandleValidators(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	shallow := r.URL.Query().Get("shallow") == "1"
+	pubkeys, err := parsePubkeys(r)
+	if err != nil {
+		writeError(w, err.Error(), http.StatusBadRequest)
+		return
+	}
 
-	out, err := h.svc.FetchPerBlockRewards(ctx, seqno, unixtime, shallow)
+	out, err := h.svc.FetchPerBlockRewards(ctx, seqno, unixtime, shallow, pubkeys)
 	if err != nil {
 		log.Printf("FetchPerBlockRewards error: %v", err)
 		writeError(w, err.Error(), http.StatusInternalServerError)
@@ -140,6 +146,11 @@ func (h *Service) HandleRoundRewards(w http.ResponseWriter, r *http.Request) {
 	}
 
 	shallow := r.URL.Query().Get("shallow") == "1"
+	pubkeys, err := parsePubkeys(r)
+	if err != nil {
+		writeError(w, err.Error(), http.StatusBadRequest)
+		return
+	}
 	var q model.RoundRewardsQuery
 
 	if hasElection {
@@ -171,7 +182,7 @@ func (h *Service) HandleRoundRewards(w http.ResponseWriter, r *http.Request) {
 		q.Unixtime = &u
 	}
 
-	out, err := h.svc.FetchRoundRewards(ctx, q, shallow)
+	out, err := h.svc.FetchRoundRewards(ctx, q, shallow, pubkeys)
 	if err != nil {
 		log.Printf("FetchRoundRewards error: %v", err)
 		writeError(w, err.Error(), http.StatusInternalServerError)
@@ -217,6 +228,35 @@ func parseUnixtime(r *http.Request) (*uint32, error) {
 	}
 	u := uint32(v)
 	return &u, nil
+}
+
+// parsePubkeys extracts the optional pubkey query parameter. Accepts repeated
+// occurrences (?pubkey=a&pubkey=b). Each value must be 64 lowercase hex chars.
+func parsePubkeys(r *http.Request) (map[string]struct{}, error) {
+	values := r.URL.Query()["pubkey"]
+	if len(values) == 0 {
+		return nil, nil
+	}
+	set := make(map[string]struct{})
+	for _, v := range values {
+		p := strings.ToLower(strings.TrimSpace(v))
+		if p == "" {
+			continue
+		}
+		if len(p) != 64 {
+			return nil, fmt.Errorf("invalid pubkey %q: expected 64 hex chars", p)
+		}
+		for _, c := range p {
+			if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
+				return nil, fmt.Errorf("invalid pubkey %q: non-hex character", p)
+			}
+		}
+		set[p] = struct{}{}
+	}
+	if len(set) == 0 {
+		return nil, nil
+	}
+	return set, nil
 }
 
 // countTrue returns how many of the given booleans are true.

--- a/model/model.go
+++ b/model/model.go
@@ -83,28 +83,30 @@ type RoundRewardsOutput struct {
 
 // ValidatorReward holds per-validator reward data for a finished round.
 type ValidatorReward struct {
-	Rank                 int               `json:"rank"`
-	Pubkey               string            `json:"pubkey"`
-	EffectiveStake       *NTon             `json:"effective_stake"`
-	Weight               float64           `json:"weight"`
-	Reward               *NTon             `json:"reward"`
-	Pool                 string            `json:"pool,omitempty"`
-	OwnerAddress         string            `json:"owner_address,omitempty"`
-	ValidatorAddress     string            `json:"validator_address,omitempty"`
-	PoolType             string            `json:"pool_type,omitempty"`
-	ValidatorStake       *NTon             `json:"validator_stake,omitempty"`
-	NominatorsStake      *NTon             `json:"nominators_stake,omitempty"`
-	TotalStake           *NTon             `json:"total_stake,omitempty"`
-	ValidatorRewardShare float64           `json:"validator_reward_share,omitempty"`
-	NominatorsCount      uint32            `json:"nominators_count,omitempty"`
-	Nominators           []NominatorReward `json:"nominators,omitempty"`
+	Rank                  int               `json:"rank"`
+	Pubkey                string            `json:"pubkey"`
+	EffectiveStake        *NTon             `json:"effective_stake"`
+	Weight                float64           `json:"weight"`
+	Reward                *NTon             `json:"reward"`
+	CurrBlockTotalBonuses *NTon             `json:"curr_block_total_bonuses,omitempty"`
+	Pool                  string            `json:"pool,omitempty"`
+	OwnerAddress          string            `json:"owner_address,omitempty"`
+	ValidatorAddress      string            `json:"validator_address,omitempty"`
+	PoolType              string            `json:"pool_type,omitempty"`
+	ValidatorStake        *NTon             `json:"validator_stake,omitempty"`
+	NominatorsStake       *NTon             `json:"nominators_stake,omitempty"`
+	TotalStake            *NTon             `json:"total_stake,omitempty"`
+	ValidatorRewardShare  float64           `json:"validator_reward_share,omitempty"`
+	NominatorsCount       uint32            `json:"nominators_count,omitempty"`
+	Nominators            []NominatorReward `json:"nominators,omitempty"`
 }
 
 // NominatorReward holds per-nominator reward data for a finished round.
 type NominatorReward struct {
-	Address        string  `json:"address"`
-	Weight         float64 `json:"weight"`
-	Reward         *NTon   `json:"reward"`
-	EffectiveStake *NTon   `json:"effective_stake"`
-	Stake          *NTon   `json:"stake"`
+	Address               string  `json:"address"`
+	Weight                float64 `json:"weight"`
+	Reward                *NTon   `json:"reward"`
+	CurrBlockTotalBonuses *NTon   `json:"curr_block_total_bonuses,omitempty"`
+	EffectiveStake        *NTon   `json:"effective_stake"`
+	Stake                 *NTon   `json:"stake"`
 }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -136,6 +136,21 @@ paths:
             type: integer
             enum: [0, 1]
             default: 0
+        - name: pubkey
+          in: query
+          description: >
+            Lowercase hex validator pubkey (64 hex chars), repeatable
+            (?pubkey=a&pubkey=b). When set, only the listed validators
+            receive deep enrichment (pool type, owner/validator addresses,
+            nominator data, returned-stake lookup); all other validators are
+            still returned but with shallow fields only. Overrides `shallow`
+            for listed validators.
+          required: false
+          explode: true
+          schema:
+            type: array
+            items:
+              type: string
       responses:
         "200":
           description: Successful response
@@ -194,6 +209,21 @@ paths:
             type: integer
             enum: [0, 1]
             default: 0
+        - name: pubkey
+          in: query
+          description: >
+            Lowercase hex validator pubkey (64 hex chars), repeatable
+            (?pubkey=a&pubkey=b). When set, only the listed validators
+            receive deep enrichment (pool type, owner/validator addresses,
+            nominator data, returned-stake lookup); all other validators are
+            still returned but with shallow fields only. Overrides `shallow`
+            for listed validators.
+          required: false
+          explode: true
+          schema:
+            type: array
+            items:
+              type: string
       responses:
         "200":
           description: Successful response
@@ -314,6 +344,18 @@ components:
           $ref: "#/components/schemas/NanoTON"
         reward_per_block:
           $ref: "#/components/schemas/NanoTON"
+        prev_block_total_bonuses:
+          allOf:
+            - $ref: "#/components/schemas/NanoTON"
+            - description: >
+                Elector's accumulated bonuses for the current round at the
+                previous masterchain block.
+        curr_block_total_bonuses:
+          allOf:
+            - $ref: "#/components/schemas/NanoTON"
+            - description: >
+                Elector's accumulated bonuses for the current round at the
+                target masterchain block.
         validators:
           type: array
           items:
@@ -402,6 +444,13 @@ components:
           example: 0.15
         reward:
           $ref: "#/components/schemas/NanoTON"
+        curr_block_total_bonuses:
+          allOf:
+            - $ref: "#/components/schemas/NanoTON"
+            - description: >
+                Nominator's share of the validator's curr_block_total_bonuses
+                after applying validator_reward_share. Only present on
+                /api/validators (per-block endpoint).
         effective_stake:
           $ref: "#/components/schemas/NanoTON"
         stake:
@@ -428,6 +477,13 @@ components:
           example: 0.004648
         reward:
           $ref: "#/components/schemas/NanoTON"
+        curr_block_total_bonuses:
+          allOf:
+            - $ref: "#/components/schemas/NanoTON"
+            - description: >
+                Validator's share of curr_block_total_bonuses, computed as
+                curr_block_total_bonuses * effective_stake / total effective
+                stake. Only present on /api/validators (per-block endpoint).
         pool:
           type: string
           description: Pool smart contract address (bounceable, base64url).

--- a/service/blocks.go
+++ b/service/blocks.go
@@ -14,7 +14,7 @@ import (
 )
 
 // FetchPerBlockRewards fetches validator statistics for the given seqno (or latest if nil).
-func (s *Service) FetchPerBlockRewards(ctx context.Context, seqno *uint32, unixtime *uint32, shallow bool) (*model.Output, error) {
+func (s *Service) FetchPerBlockRewards(ctx context.Context, seqno *uint32, unixtime *uint32, shallow bool, pubkeys map[string]struct{}) (*model.Output, error) {
 	client := s.currentClient()
 	ctx = WithLoaders(ctx, client)
 
@@ -204,6 +204,6 @@ func (s *Service) FetchPerBlockRewards(ctx context.Context, seqno *uint32, unixt
 	out.TotalStake = &model.NTon{Int: totalTrueStake}
 	log.Printf("total true stake (active validators): %.2f TON", new(big.Float).Quo(new(big.Float).SetInt(totalTrueStake), big.NewFloat(1e9)))
 
-	out.Validators = computeValidatorRewards(ctx, pinned, rows, totalTrueStake, rewardPerBlock, shallow)
+	out.Validators = computeValidatorRewards(ctx, pinned, rows, totalTrueStake, rewardPerBlock, shallow, pubkeys, currBlockBonuses)
 	return &out, nil
 }

--- a/service/blocks.go
+++ b/service/blocks.go
@@ -14,7 +14,7 @@ import (
 )
 
 // FetchPerBlockRewards fetches validator statistics for the given seqno (or latest if nil).
-func (s *Service) FetchPerBlockRewards(ctx context.Context, seqno *uint32, unixtime *uint32, shallow bool, pubkeys map[string]struct{}) (*model.Output, error) {
+func (s *Service) FetchPerBlockRewards(ctx context.Context, seqno *uint32, unixtime *uint32, shallow bool, pubkeys map[string]bool) (*model.Output, error) {
 	client := s.currentClient()
 	ctx = WithLoaders(ctx, client)
 

--- a/service/integration_test.go
+++ b/service/integration_test.go
@@ -94,7 +94,7 @@ func TestFetchPerBlockRewardsMatchesSnapshots(t *testing.T) {
 			seqno := snap.Block.Seqno
 			out, err := svc.FetchRoundRewards(ctx, model.RoundRewardsQuery{
 				ElectionID: &snap.ElectionID,
-			}, false)
+			}, false, nil)
 			if err != nil {
 				t.Fatalf("FetchPerBlockRewards(seqno=%d): %v", seqno, err)
 			}
@@ -236,7 +236,7 @@ func TestTonscanElectionMatchesService(t *testing.T) {
 
 			out, err := svc.FetchRoundRewards(ctx, model.RoundRewardsQuery{
 				ElectionID: &d.ID,
-			}, false)
+			}, false, nil)
 			if err != nil {
 				t.Fatalf("FetchRoundRewards(election=%d): %v", d.ID, err)
 			}

--- a/service/integration_test.go
+++ b/service/integration_test.go
@@ -144,6 +144,132 @@ func TestFetchPerBlockRewardsMatchesSnapshots(t *testing.T) {
 			if wrongCount > 0 {
 				t.Fatalf("wrong count: %d", wrongCount)
 			}
+
+			// Pubkey filter: re-run the same round with shallow=true and a
+			// small pubkey allowlist. Selected validators must still receive
+			// deep enrichment (TotalStake populated), all others must stay
+			// shallow. The full call above is the oracle for which pubkeys
+			// can actually deep-enrich (those with TotalStake set).
+			var selectedPubkeys []string
+			for _, v := range out.Validators {
+				if v.TotalStake != nil {
+					selectedPubkeys = append(selectedPubkeys, v.Pubkey)
+					if len(selectedPubkeys) == 2 {
+						break
+					}
+				}
+			}
+			if len(selectedPubkeys) == 0 {
+				t.Logf("no deep-enriched validators available to exercise pubkey filter")
+			} else {
+				selected := make(map[string]bool, len(selectedPubkeys))
+				for _, p := range selectedPubkeys {
+					selected[p] = true
+				}
+
+				fctx, fcancel := context.WithTimeout(context.Background(), 120*time.Second)
+				defer fcancel()
+				filtered, err := svc.FetchRoundRewards(fctx, model.RoundRewardsQuery{
+					ElectionID: &snap.ElectionID,
+				}, true, selected)
+				if err != nil {
+					t.Fatalf("FetchRoundRewards(pubkeys=%v): %v", selectedPubkeys, err)
+				}
+
+				if len(filtered.Validators) != len(out.Validators) {
+					t.Errorf("pubkey filter changed validator count: got %d, want %d",
+						len(filtered.Validators), len(out.Validators))
+				}
+
+				filteredByPubkey := make(map[string]*model.ValidatorReward, len(filtered.Validators))
+				for i := range filtered.Validators {
+					filteredByPubkey[filtered.Validators[i].Pubkey] = &filtered.Validators[i]
+				}
+
+				// Every selected pubkey must appear with deep-enrichment fields.
+				for _, p := range selectedPubkeys {
+					fv, ok := filteredByPubkey[p]
+					if !ok {
+						t.Errorf("selected pubkey %s: missing from filtered output", p)
+						continue
+					}
+					if fv.TotalStake == nil {
+						t.Errorf("selected pubkey %s: TotalStake nil; want deep enrichment despite shallow=true", p)
+					}
+				}
+
+				// Non-selected validators must remain shallow even though the
+				// oracle call deep-enriched them.
+				for _, fv := range filtered.Validators {
+					if _, isSelected := selected[fv.Pubkey]; isSelected {
+						continue
+					}
+					if fv.TotalStake != nil {
+						t.Errorf("unselected pubkey %s: TotalStake = %s; expected shallow", fv.Pubkey, fv.TotalStake.Int)
+					}
+					if fv.PoolType != "" {
+						t.Errorf("unselected pubkey %s: PoolType = %q; expected shallow", fv.Pubkey, fv.PoolType)
+					}
+					if fv.NominatorsCount != 0 {
+						t.Errorf("unselected pubkey %s: NominatorsCount = %d; expected shallow", fv.Pubkey, fv.NominatorsCount)
+					}
+					if len(fv.Nominators) != 0 {
+						t.Errorf("unselected pubkey %s: %d nominators returned; expected shallow", fv.Pubkey, len(fv.Nominators))
+					}
+				}
+			}
+
+			// Per-block bonuses: call FetchPerBlockRewards at the snapshot
+			// seqno and verify the new prev/curr_block_total_bonuses fields
+			// plus the per-validator bonus split invariant.
+			pbCtx, pbCancel := context.WithTimeout(context.Background(), 120*time.Second)
+			defer pbCancel()
+			pb, err := svc.FetchPerBlockRewards(pbCtx, &seqno, nil, true, nil)
+			if err != nil {
+				t.Fatalf("FetchPerBlockRewards(seqno=%d): %v", seqno, err)
+			}
+			if pb.PrevBlockTotalBonuses == nil || pb.PrevBlockTotalBonuses.Int == nil {
+				t.Errorf("prev_block_total_bonuses missing from per-block response")
+			}
+			if pb.CurrBlockTotalBonuses == nil || pb.CurrBlockTotalBonuses.Int == nil {
+				t.Fatalf("curr_block_total_bonuses missing from per-block response")
+			}
+			if pb.CurrBlockTotalBonuses.Sign() < 0 || pb.PrevBlockTotalBonuses.Sign() < 0 {
+				t.Errorf("bonuses must be non-negative: prev=%s curr=%s", pb.PrevBlockTotalBonuses.Int, pb.CurrBlockTotalBonuses.Int)
+			}
+			if pb.CurrBlockTotalBonuses.Cmp(pb.PrevBlockTotalBonuses.Int) < 0 {
+				t.Errorf("curr_block_total_bonuses (%s) < prev_block_total_bonuses (%s); bonuses are monotonic within a round",
+					pb.CurrBlockTotalBonuses.Int, pb.PrevBlockTotalBonuses.Int)
+			}
+
+			// Per-validator curr_block_total_bonuses = curr * stake / total_stake.
+			// Only meaningful when the elector has accumulated bonuses at this block.
+			if pb.CurrBlockTotalBonuses.Sign() > 0 && pb.TotalStake != nil && pb.TotalStake.Sign() > 0 {
+				sum := new(big.Int)
+				for _, v := range pb.Validators {
+					if v.CurrBlockTotalBonuses == nil {
+						t.Errorf("validator %s: curr_block_total_bonuses missing in per-block response", v.Pubkey)
+						continue
+					}
+					want := new(big.Int).Mul(pb.CurrBlockTotalBonuses.Int, v.EffectiveStake.Int)
+					want.Quo(want, pb.TotalStake.Int)
+					if v.CurrBlockTotalBonuses.Cmp(want) != 0 {
+						t.Errorf("validator %s: curr_block_total_bonuses = %s; want %s (curr*stake/total)",
+							v.Pubkey, v.CurrBlockTotalBonuses.Int, want)
+					}
+					sum.Add(sum, v.CurrBlockTotalBonuses.Int)
+				}
+				// Sum of truncated splits is at most top-level value and at
+				// least top-level minus len(validators) (each MulDiv loses <1).
+				diff := new(big.Int).Sub(pb.CurrBlockTotalBonuses.Int, sum)
+				if diff.Sign() < 0 {
+					t.Errorf("sum of per-validator bonuses (%s) exceeds total (%s)", sum, pb.CurrBlockTotalBonuses.Int)
+				}
+				if diff.Cmp(big.NewInt(int64(len(pb.Validators)))) > 0 {
+					t.Errorf("sum of per-validator bonuses (%s) trails total (%s) by more than %d (rounding tolerance)",
+						sum, pb.CurrBlockTotalBonuses.Int, len(pb.Validators))
+				}
+			}
 		})
 	}
 

--- a/service/rounds.go
+++ b/service/rounds.go
@@ -218,7 +218,7 @@ func getConfigParam34(ctx context.Context, client LiteClient, ext ton.BlockIDExt
 
 // FetchRoundRewards computes per-validator and per-nominator reward distribution
 // for a finished validation round using the elector's bonuses value.
-func (s *Service) FetchRoundRewards(ctx context.Context, query model.RoundRewardsQuery, shallow bool) (*model.RoundRewardsOutput, error) {
+func (s *Service) FetchRoundRewards(ctx context.Context, query model.RoundRewardsQuery, shallow bool, pubkeys map[string]struct{}) (*model.RoundRewardsOutput, error) {
 	client := s.currentClient()
 	ctx = WithLoaders(ctx, client)
 
@@ -286,7 +286,7 @@ func (s *Service) FetchRoundRewards(ctx context.Context, query model.RoundReward
 	bonuses := el.Bonuses
 	electionTotalStake := el.TotalStake
 
-	validatorRewards := computeValidatorRewards(ctx, nextRoundPinned, rows, totalTrueStake, bonuses, shallow)
+	validatorRewards := computeValidatorRewards(ctx, nextRoundPinned, rows, totalTrueStake, bonuses, shallow, pubkeys, nil)
 
 	out := &model.RoundRewardsOutput{
 		ElectionID:   electionID,

--- a/service/rounds.go
+++ b/service/rounds.go
@@ -218,7 +218,7 @@ func getConfigParam34(ctx context.Context, client LiteClient, ext ton.BlockIDExt
 
 // FetchRoundRewards computes per-validator and per-nominator reward distribution
 // for a finished validation round using the elector's bonuses value.
-func (s *Service) FetchRoundRewards(ctx context.Context, query model.RoundRewardsQuery, shallow bool, pubkeys map[string]struct{}) (*model.RoundRewardsOutput, error) {
+func (s *Service) FetchRoundRewards(ctx context.Context, query model.RoundRewardsQuery, shallow bool, pubkeys map[string]bool) (*model.RoundRewardsOutput, error) {
 	client := s.currentClient()
 	ctx = WithLoaders(ctx, client)
 

--- a/service/shared.go
+++ b/service/shared.go
@@ -198,7 +198,7 @@ func findElection(elections []RawPastElection, electAt int64) *RawPastElection {
 // output with shallow fields only.
 // bonusesPool, when non-nil, is used to compute a per-validator (and per-nominator)
 // share of the round's accumulated bonuses following the same split as reward.
-func computeValidatorRewards(ctx context.Context, pinned LiteClient, rows []validatorRow, totalTrueStake, rewardPool *big.Int, shallow bool, pubkeys map[string]struct{}, bonusesPool *big.Int) []model.ValidatorReward {
+func computeValidatorRewards(ctx context.Context, pinned LiteClient, rows []validatorRow, totalTrueStake, rewardPool *big.Int, shallow bool, pubkeys map[string]bool, bonusesPool *big.Int) []model.ValidatorReward {
 	type rewardRow struct {
 		validatorRow
 		reward           *big.Int
@@ -242,12 +242,8 @@ func computeValidatorRewards(ctx context.Context, pinned LiteClient, rows []vali
 			}
 
 			rowShallow := shallow
-			if len(pubkeys) > 0 {
-				if _, match := pubkeys[validatorRewards[i].Pubkey]; match {
-					rowShallow = false
-				} else {
-					rowShallow = true
-				}
+			if pubkeys != nil {
+				rowShallow = !pubkeys[validatorRewards[i].Pubkey]
 			}
 			if rowShallow || row.poolAddr == nil {
 				return nil

--- a/service/shared.go
+++ b/service/shared.go
@@ -193,10 +193,16 @@ func findElection(elections []RawPastElection, electAt int64) *RawPastElection {
 // computeValidatorRewards computes per-validator rewards, sorts by stake, and
 // enriches each validator with pool data and nominator reward splits in parallel.
 // rewardPool is the total reward to distribute (bonuses for round rewards, rewardPerBlock for per-block).
-func computeValidatorRewards(ctx context.Context, pinned LiteClient, rows []validatorRow, totalTrueStake, rewardPool *big.Int, shallow bool) []model.ValidatorReward {
+// pubkeys, when non-nil, selects which validators receive deep enrichment even
+// when shallow is true. Non-matching validators are still included in the
+// output with shallow fields only.
+// bonusesPool, when non-nil, is used to compute a per-validator (and per-nominator)
+// share of the round's accumulated bonuses following the same split as reward.
+func computeValidatorRewards(ctx context.Context, pinned LiteClient, rows []validatorRow, totalTrueStake, rewardPool *big.Int, shallow bool, pubkeys map[string]struct{}, bonusesPool *big.Int) []model.ValidatorReward {
 	type rewardRow struct {
 		validatorRow
-		reward *big.Int
+		reward           *big.Int
+		currBlockBonuses *big.Int
 	}
 	rewardRows := make([]rewardRow, len(rows))
 	for i, row := range rows {
@@ -206,7 +212,15 @@ func computeValidatorRewards(ctx context.Context, pinned LiteClient, rows []vali
 		} else {
 			reward = new(big.Int)
 		}
-		rewardRows[i] = rewardRow{validatorRow: row, reward: reward}
+		var currBlockBonuses *big.Int
+		if bonusesPool != nil {
+			if totalTrueStake.Sign() > 0 {
+				currBlockBonuses = utils.MulDiv(bonusesPool, row.trueStake, totalTrueStake)
+			} else {
+				currBlockBonuses = new(big.Int)
+			}
+		}
+		rewardRows[i] = rewardRow{validatorRow: row, reward: reward, currBlockBonuses: currBlockBonuses}
 	}
 	sort.Slice(rewardRows, func(i, j int) bool { return rewardRows[i].trueStake.Cmp(rewardRows[j].trueStake) > 0 })
 
@@ -223,8 +237,19 @@ func computeValidatorRewards(ctx context.Context, pinned LiteClient, rows []vali
 				Reward:         &model.NTon{Int: row.reward},
 				Pool:           row.pool,
 			}
+			if row.currBlockBonuses != nil {
+				validatorRewards[i].CurrBlockTotalBonuses = &model.NTon{Int: row.currBlockBonuses}
+			}
 
-			if shallow || row.poolAddr == nil {
+			rowShallow := shallow
+			if len(pubkeys) > 0 {
+				if _, match := pubkeys[validatorRewards[i].Pubkey]; match {
+					rowShallow = false
+				} else {
+					rowShallow = true
+				}
+			}
+			if rowShallow || row.poolAddr == nil {
 				return nil
 			}
 
@@ -274,6 +299,17 @@ func computeValidatorRewards(ctx context.Context, pinned LiteClient, rows []vali
 			nominatorsReward := new(big.Int).Sub(totalValidatorReward, validatorSelfReward)
 			nominatorsTotalStake := info.pd.NominatorsAmount
 
+			// Same split applied to the per-validator share of curr_block_total_bonuses.
+			var nominatorsBonuses *big.Int
+			if row.currBlockBonuses != nil {
+				totalValidatorBonuses := row.currBlockBonuses
+				validatorSelfBonuses := utils.MulDiv(totalValidatorBonuses, rewardShare, tenThousand)
+				if validatorSelfBonuses.Cmp(totalValidatorBonuses) > 0 {
+					validatorSelfBonuses.Set(totalValidatorBonuses)
+				}
+				nominatorsBonuses = new(big.Int).Sub(totalValidatorBonuses, validatorSelfBonuses)
+			}
+
 			for _, n := range info.pd.Nominators {
 				addr := ton.AccountID{Workchain: 0, Address: tlb.Bits256(n.Address)}
 				nominatorStake := new(big.Int).SetUint64(n.Amount)
@@ -291,13 +327,18 @@ func computeValidatorRewards(ctx context.Context, pinned LiteClient, rows []vali
 
 				nominatorEffectiveStake := utils.MulDiv(nominatorStake, row.trueStake, totalStake)
 
-				validatorRewards[i].Nominators = append(validatorRewards[i].Nominators, model.NominatorReward{
+				nr := model.NominatorReward{
 					Address:        addr.ToHuman(true, false),
 					Weight:         utils.InaccurateDivFloat(nominatorStake, nominatorsTotalStake),
 					Reward:         &model.NTon{Int: nominatorReward},
 					EffectiveStake: &model.NTon{Int: nominatorEffectiveStake},
 					Stake:          &model.NTon{Int: nominatorStake},
-				})
+				}
+				if nominatorsBonuses != nil {
+					nominatorBonuses := utils.MulDiv(nominatorsBonuses, nominatorStake, nominatorsTotalStake)
+					nr.CurrBlockTotalBonuses = &model.NTon{Int: nominatorBonuses}
+				}
+				validatorRewards[i].Nominators = append(validatorRewards[i].Nominators, nr)
 			}
 
 			return nil


### PR DESCRIPTION
- Introduced a new `pubkey` query parameter for deep enrichment of specified validators.
- Added `prev_block_total_bonuses` and `curr_block_total_bonuses` fields to the API responses for both elector and validator data.
- Updated relevant service methods and models to accommodate the new bonuses and query parameter functionality.